### PR TITLE
Add -p flag to mkdir

### DIFF
--- a/base.mk
+++ b/base.mk
@@ -13,6 +13,6 @@ update-submodule:
 
 auto-lint:
 	pip install --upgrade autopep8
-	mkdir .git/hooks
+	mkdir -p .git/hooks
 	curl https://gist.githubusercontent.com/lucidlogic/ef3de91857197512944bcde82c5fdb03/raw/7d3e880e53f68935b50093fc0c9cfebf7a6669f7/pre-commit --output .git/hooks/pre-commit
 	chmod +x .git/hooks/pre-commit


### PR DESCRIPTION
This ensures the command doesn't barf if the hooks directory exists already