### PR TITLE
Uninstall from file after install local requirements

### DIFF
--- a/base.mk
+++ b/base.mk
@@ -7,6 +7,9 @@ install-requirements:
 install-local-requirements:
 	python -m pip install --upgrade pip;
 	pip install -r requirements.txt -t ./;
+	if [ -f "uninstall.txt" ]; then
+	  pip uninstall -r uninstall.txt -y;
+	fi
 
 update-submodule:
 	git submodule update --remote --merge


### PR DESCRIPTION
It doesn't seem possible to have a package in the `install_requires` in `setup.py` with the `no-deps` flag. In sdc-engine-helpers, `sagemaker` is a dependency, but we don't need the large sub-dependency `scipy`.

Proposed solution is to have an optional `uninstall.txt` file in any one of our repos, which `make install-local-requirements` will uninstall post all installations